### PR TITLE
BlockOptions token contract updated

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -189,7 +189,7 @@
     { "addr": "0xb7cb1c96db6b22b0d3d9536e0108d062bd488f74", "name": "WTC", "decimals": 18 },
     { "addr": "0x5ca9a71b1d01849c0a95490cc00559717fcf0d1d", "name": "AE", "decimals": 18 },
     { "addr": "0x336f646f87d9f6bc6ed42dd46e8b3fd9dbd15c22", "name": "CCT", "decimals": 18 },
-    { "addr": "0x9Cb9eb4BB7800BDbB017be2A4fFBECCb67454eA9", "name": "BOPT", "decimals": 8 }
+    { "addr": "0x7f1e2c7d6a69bf34824d72c53b4550e895c0d8c2", "name": "BOP", "decimals": 8 }
   ],
   "defaultPair": { "token": "PPT", "base": "ETH" },
   "pairs": [
@@ -345,6 +345,6 @@
     { "token": "WTC", "base": "ETH" },
     { "token": "AE", "base": "ETH" },
     { "token": "CCT", "base": "ETH" },
-    { "token": "BOPT", "base": "ETH" }
+    { "token": "BOP", "base": "ETH" }
   ]
 }


### PR DESCRIPTION
Hi, due to our old token contract have a security issue, we have to replace it with a new one. And we have replaced it on our website: http://blockoptions.io/. 

We also have transfered the same amount of 36569.029tokens to etherdelta's address  0x8d12a197cb00d4747a1fe03395095ce2a5cc6819 and others's addresses but excluding hackers.

Two hackers stolen 196,426.34 + 12.5K tokens from us by calling the main_ico function directly. We have corrected it on new token contract.

Hacker #1:
https://etherscan.io/tx/0xbd7f6c07d7b11d4114be034234f2ef82c84350217737d37eb92a32a862e73a29
https://etherscan.io/token/0x9cb9eb4bb7800bdbb017be2a4ffbeccb67454ea9?a=0x24ababce7d3ca6198e7e1920ed2b6d1d1a216153

Hacker #2:
https://etherscan.io/tx/0x13872043c3277517916e7298e481101d1935a656548a9a271b96a91604f868a3
https://etherscan.io/token/0x9cb9eb4bb7800bdbb017be2a4ffbeccb67454ea9?a=0x8eae37dd1b2bef711626f608f50614694ef219e9

Hacker 2 have sold 30K tokens on etherdelta, we can't do anything about it. Please help us updating it asap. Thank you very much!